### PR TITLE
Correct the leaderboard link

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -12,7 +12,7 @@
     NavItem.reopenClass({
         buildList : function(category, args) {
           var list = this._super(category, args);
-          list.push(ExternalNavItem.create({href: '/forum/users', name: 'users'}));
+          list.push(ExternalNavItem.create({href: '/users', name: 'users'}));
           return list;
         }
     });


### PR DESCRIPTION
Changes the link to point to `/users` instead of `/forum/users`. Fixes issue [39156](https://github.com/freeCodeCamp/freeCodeCamp/issues/39156) on the main repo. 